### PR TITLE
removed cached files before install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
                 sh "npm config set always-auth true"
                 sh "npm config set strict-ssl true"
                 sh "npm config ls"
+                sh 'rm -rf node_modules'
                 sh 'npm install' 
             }
         }


### PR DESCRIPTION
```
+ npm run build

> tracker-website@0.1.0 build
> react-scripts build

sh: 1: react-scripts: not found
npm ERR! code 127
npm ERR! path /var/jenkins_home/workspace/activity-tracker-website
npm ERR! command failed
npm ERR! command sh -c react-scripts build
```
`node_modules` should probably be reinstalled 